### PR TITLE
update dataset link to estuary gateway

### DIFF
--- a/src/components/Dataset/DatasetContent/MetaFull.tsx
+++ b/src/components/Dataset/DatasetContent/MetaFull.tsx
@@ -25,11 +25,11 @@ export default function MetaFull({
       cids.map((cid) => (
         <code key={cid}>
           <a
-            href={`https://ipfs.io/ipfs/${cid}`}
+            href={`https://api.estuary.tech/gw/ipfs/${cid}`}
             target="_blank"
             rel="noreferrer"
           >
-            {`https://ipfs.io/ipfs/${cid}`}
+            {`https://api.estuary.tech/gw/ipfs/${cid}`}
           </a>
         </code>
       ))


### PR DESCRIPTION
ipfs.io and dweb.io IPFS gateways seem to unreliable, switching to estuary gateway as suggested by their team on Slack Convo

https://filecoinproject.slack.com/archives/C016APFREQK/p1667773496637429

**Note: Only Merge this PR when the Estuary team resolves their UI Bug**